### PR TITLE
Nick's updates with helm-chart & Actions job

### DIFF
--- a/.github/workflows/cicd-workflow.yaml
+++ b/.github/workflows/cicd-workflow.yaml
@@ -1,0 +1,71 @@
+name: LENS2 CICD Pipeline
+
+# Start the workflow when any updates are made to the src directory in GitHub
+on: 
+  push:
+    paths:
+      - src/**
+    branches:
+      - refactor_0815
+
+
+jobs:
+  docker-stuff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo 
+        uses: actions/checkout@v3
+# Login to DockerHub. Setup Repository secrets with your DockerHub username and a Token
+# This is found in Settings - > Security -> Secrets and variables -> Actions -> Repository Secrets
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+# We use the current date as the tag for the Docker image
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d.%H.%M')" >> $GITHUB_OUTPUT
+# Build the LENS2 Docker image and push it to DockerHub
+      - name: Build and push Lens 2 Docker image
+        uses: docker/build-push-action@v4
+        with:
+          # Provide the current directory as build context 
+          context: .
+          # Specify where the Dockerfile is located in relation to the repo base path
+          file: Dockerfile
+          # Enable the push to docker hub
+          push: true
+          # Provide the tags to apply to the image, this example uses the latest image tag 
+          tags: |
+            ncote/LENS2:${{ steps.date.outputs.date }}
+# Build the LENS2 Dask Docker image and push it to DockerHub
+# We need to include a custom dask image with our data and python packages
+      - name: Build and push Lens 2 Docker image
+        uses: docker/build-push-action@v4
+        with:
+          # Provide the current directory as build context 
+          context: .
+          # Specify where the Dockerfile is located in relation to the repo base path
+          file: Dockerfile.dask
+          # Enable the push to docker hub
+          push: true
+          # Provide the tags to apply to the image, this example uses the latest image tag 
+          tags: |
+            ncote/dask-lens2:${{ steps.date.outputs.date }}
+      - name: Update Helm values.yaml
+        run: |
+          sed -i "/lens2 c\    image: ncote/LENS2:${{ steps.date.outputs.date }}" lens2-helm/values.yaml
+          sed -i "/dask-lens2 c\    image: ncote/dask-lens2:${{ steps.date.outputs.date }}" lens2-helm/values.yaml
+      - name: Update Helm Chart.yaml
+        run: |
+          sed -i "/appVersion:/ c\appVersion: ${{ steps.date.outputs.date }}" lens2-helm/Chart.yaml
+      - name: Run python script to update version by 1
+        run: python update_ver.py
+      - name: Push changes to GitHub
+        run: |
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git config --global user.name "$GITHUB_ACTOR"
+          git commit -a -m "Update Helm chart via GH Actions"
+          git push
+

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ After creating and activating environment:
 3. Start panel server
 
 `panel serve src/cesm-2-dashboard/app.py --allow-websocket-origin="*" --autoreload`
+
+
+
+Data: https://drive.google.com/file/d/1GF5UiAb7QJ5eeNh7p4Y2EzXVh10A6Bbt/view?usp=drive_link

--- a/README.md
+++ b/README.md
@@ -14,23 +14,35 @@ This repository hosts notebooks and code written to visualize the [CESM-LENS2](h
 
 3. Create conda environment:
 
-`conda create --prefix ./.env --file environment.yml`
+# `conda create --prefix ./.env --file environment.yml`
+
+`conda env create --file environment.yml -n lens2`
+or 
+`mamba env create --file environment.yml -n lens2`
+
+4. activate the environment:
+
+`conda activate lens2`
 
 
-4. Start a jupyterlab session and run the notebooks. Start jupyterlab session:
+## Exploring via notebook: 
+
+5. Start a jupyterlab session and run the notebooks. Start jupyterlab session:
 
 `jupyter lab`
 
 
-## Serve the app
+## Serve the app from outside notebook:
 
-1. Start a dask scheduler
+After creating and activating environment:
 
-`dask scheduler --host localhost --port 8786`
+1. In one terminal, start a dask scheduler
+
+`dask scheduler --host localhost --port 8786 &`
 
 2. Start dask workers - 2 workers, with 2GB memory each
 
-`dask worker --host localhost --nworkers 2 --memory-limit '2GB' localhost:8786`
+`dask worker --host localhost --nworkers 2 --memory-limit '2GB' localhost:8786 &`
 
 3. Start panel server
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This repository hosts notebooks and code written to visualize the [CESM-LENS2](h
 
 3. Create conda environment:
 
-# `conda create --prefix ./.env --file environment.yml`
-
 `conda env create --file environment.yml -n lens2`
 or 
 `mamba env create --file environment.yml -n lens2`


### PR DESCRIPTION
Nick has update with a new Helm chart that can be customized for Argo CD deployments, there is also a GitHub actions file but it doesn't work for building the Docker image so this should be disabled for now. Updates to the Readme include running locally on Docker and running on K8s via Helm and Argo